### PR TITLE
Include missing header file

### DIFF
--- a/pfpsim/core/PFPConfig.h
+++ b/pfpsim/core/PFPConfig.h
@@ -47,6 +47,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <sstream>
 #include "systemc.h"
 
 #define INPUT_FILE_ERROR -7


### PR DESCRIPTION
Include header file somehow missed for stringstream. 