### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - env: COMPILER=g++-4.8
     - env: COMPILER=g++-5
-    - env: COMPILER=clang++-3.5
+    #- env: COMPILER=clang++-3.5
 
 # N.B. - The P4 cmake configure step under Travis will install all of its dependencies,
 # some of which overlap with our dependencies. Notably:


### PR DESCRIPTION
Temporarily removing build support for clang3.5 see Build#44 due to upstream error in p4-behavioural. :see_no_evil: